### PR TITLE
fix(site): 英文首页主 CTA 改为「进入教程」,与中文版对称

### DIFF
--- a/en/index.md
+++ b/en/index.md
@@ -4,10 +4,13 @@ layout: home
 hero:
   name: "Awesome Architecture"
   text: "Think like an architect"
-  tagline: "Writing code is disappearing; judgment is what's getting valuable. 26 chapters on architectural thinking (foundations + advanced + practice + AI-collab; last two tracks planned) + 25 architecture maps of real systems — architecture only, no syntax."
+  tagline: "Writing code is disappearing; judgment is what's getting valuable. 26 chapters on architectural thinking (foundations + advanced complete; practice track in progress; AI-collab planned) + 25 architecture maps of real systems — architecture only, no syntax."
   actions:
     - theme: brand
-      text: Browse in 中文 →
+      text: Start the tutorial →
+      link: /en/tutorial/README
+    - theme: alt
+      text: Browse in 中文
       link: /
     - theme: alt
       text: GitHub
@@ -28,4 +31,4 @@ features:
     details: Each template links to real open-source projects and engineering papers (vLLM, LiteLLM, TigerBeetle, Uber H3, Figma…).
 ---
 
-> 🚧 **English translation in progress.** The full tutorial and all 21 templates are currently written in Chinese (and complete). Chapters are being translated one by one — [contributions welcome](https://github.com/study8677/awesome-architecture).
+> ✅ **Fully bilingual.** All 26 tutorial chapters and 25 templates are available in English — use the language switch (top-right) or browse `en/` in the repo. [Contributions welcome](https://github.com/study8677/awesome-architecture).


### PR DESCRIPTION
## 问题

`en/index.md` 的 brand 主按钮是 `Browse in 中文 → /`——已经在英文页的读者,点最显眼的按钮反而被送回中文,**完全反了**。中文首页对应的按钮是「开始学习 → /tutorial/README」,英文应对称。

## 改动

```diff
  actions:
-   - theme: brand
-     text: Browse in 中文 →
-     link: /
+   - theme: brand
+     text: Start the tutorial →
+     link: /en/tutorial/README
+   - theme: alt
+     text: Browse in 中文
+     link: /
    - theme: alt
      text: GitHub
```

「Browse in 中文」降级为 alt 次按钮,顶栏右上的语言切换器仍在。

顺手把 tagline 改成准确反映当前发布状态:「foundations + advanced complete; practice track in progress; AI-collab planned」(本地之前那版「all complete」不实,20-26 + AI 协同篇尚未上线)。

## 验证

用「临时移走 20-26 模拟远端只有 18-19」的方式跑 `vitepress build`,3.83s 通过、无死链。