### PR TITLE
docs(site): 英文首页补齐互动内容(决策卡 / Quiz / 收尾 CTA)

### DIFF
--- a/en/index.md
+++ b/en/index.md
@@ -31,4 +31,30 @@ features:
     details: Each template links to real open-source projects and engineering papers (vLLM, LiteLLM, TigerBeetle, Uber H3, Figma…).
 ---
 
-> ✅ **Fully bilingual.** All 26 tutorial chapters and 25 templates are available in English — use the language switch (top-right) or browse `en/` in the repo. [Contributions welcome](https://github.com/study8677/awesome-architecture).
+> 📝 **Bilingual** — all **19 published tutorial chapters and 25 templates** are available in English; **the rest of the practice track (20–22) and the AI-collaborative design track (23–26) are planned.** Use the language switch (top-right) or browse `en/` in the repo. [Contributions welcome](https://github.com/study8677/awesome-architecture).
+
+## ⚖️ Architecture is a series of forks in the road
+
+The most valuable section of every template is "Key Decisions & Trade-offs." Try this interactive starter:
+
+<DecisionCard
+  title="Monolith or Microservices?"
+  a="Monolith"
+  aDesc="One deployable unit, in-process function calls. Simple, debuggable, light on ops."
+  b="Microservices"
+  bDesc="Multiple independently deployed services calling each other over the network. Independent scaling and release, but you inherit the full burden of distributed systems."
+  verdict="Default to a 'modular monolith' first. Microservices first solve a *people* scaling problem (multiple teams blocking each other in one codebase), not a *machine* performance problem — splitting prematurely, without the org size, independent-deployment need, and platform muscle in place, is self-inflicted pain."
+/>
+
+## 🤔 First, a warm-up
+
+Before diving in, check your gut sense of 'architecture':
+
+<Quiz
+  question="Which of the following is closest to the essence of 'architecture'?"
+  :options="['A diagram with a few boxes connected by lines', 'A set of decisions that are hard to change, cross-cutting, and decide quality attributes', 'Just use the newest frameworks and microservices']"
+  :answer="1"
+  explanation="Architecture = the decisions that, once made, are hard to change, affect the whole system, and decide whether it is *good*. Diagrams are how decisions get expressed; the *why* behind decisions is the soul."
+/>
+
+Ready? 👉 [Start from Chapter 01](/en/tutorial/01-为什么先有架构思维), or browse [25 architecture maps](https://github.com/study8677/awesome-architecture/tree/main/en/templates) on GitHub.


### PR DESCRIPTION
之前英文首页只有 hero + features + 一行小横幅,中文版底下还有 4 块互动内容。本次补齐 3 块(ArchExplorer 因 25 个硬编码中文名需另做 i18n,留作单独 PR):

- **DecisionCard**:Monolith vs Microservices 决策卡
- **Quiz**:热身随堂测验「architecture 的本质是什么?」
- **收尾 CTA**:`Start from Chapter 01` 链到 `/en/tutorial/01-...`;`Browse 25 architecture maps` 链到 GitHub 的 `en/templates/` 文件夹

顺手修一处前后矛盾——tagline 写「practice in progress; AI-collab planned」,横幅却仍写「All 26 chapters available」(我前几轮没同步好)。横幅按 README_en.md 第 142 行口径改为「19 published chapters; the rest is planned」。

已用「移走 20-26 模拟远端」方式跑 `vitepress build`,3.54s 通过、无死链。