### PR TITLE
feat(comments): 划词标注默认关闭,评论区顶部加 toggle 按钮

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -79,8 +79,8 @@ export default defineConfig({
     ['meta', { name: 'theme-color', content: '#3c8772' }],
     ['meta', { property: 'og:title', content: 'Awesome Architecture · 架构图谱' }],
     ['meta', { property: 'og:description', content: '像架构师一样思考:19 章教程(入门 + 进阶 + 实战连载中)+ 25 张真实系统架构地图。' }],
-    // Hypothesis 划词标注:选中正文文字即可高亮 + 评论,标注持久化、所有访客可见
-    ['script', { src: 'https://hypothes.is/embed.js', async: '' }],
+    // 注:Hypothesis 划词标注不再全站默认加载;改由评论区顶部的 toggle 按需注入。
+    // 见 .vitepress/theme/components/Comments.vue 的 loadHypothesis()。
   ],
 
   themeConfig: {

--- a/.vitepress/theme/components/Comments.vue
+++ b/.vitepress/theme/components/Comments.vue
@@ -15,6 +15,7 @@ const container = ref<HTMLElement | null>(null)
 
 const giscusTheme = () => (isDark.value ? 'dark' : 'light')
 const giscusLang = () => (lang.value?.startsWith('en') ? 'en' : 'zh-CN')
+const isEn = () => giscusLang() === 'en'
 
 // 每次进入新页面都重新挂载脚本,这样每篇文档对应自己的 Discussion(按 pathname 映射)
 function load() {
@@ -52,14 +53,70 @@ function syncTheme() {
   )
 }
 
-onMounted(load)
+// ─────────────── Hypothesis 划词标注:默认关闭、按需开启 ───────────────
+// 历史上 config.mts 里曾全站默认挂载 hypothes.is/embed.js,会让侧边栏在
+// 每个页面都默认露面。现改为:默认不加载,用户在评论区顶部按钮里手动启用,
+// 偏好存 localStorage 跨页持久。
+const annotationsEnabled = ref(false)
+const STORAGE_KEY = 'awesome-arch-annotations-enabled'
+const HYPOTHESIS_SCRIPT_ID = 'hypothesis-embed-script'
+
+function loadHypothesis() {
+  if (typeof document === 'undefined') return
+  if (document.getElementById(HYPOTHESIS_SCRIPT_ID)) return // 已加载,避免重复注入
+  const s = document.createElement('script')
+  s.id = HYPOTHESIS_SCRIPT_ID
+  s.src = 'https://hypothes.is/embed.js'
+  s.async = true
+  document.head.appendChild(s)
+}
+
+function toggleAnnotations() {
+  if (typeof window === 'undefined') return
+  if (annotationsEnabled.value) {
+    // 已开启 → 关闭:清偏好,刷新页面让 Hypothesis 完全离场
+    localStorage.removeItem(STORAGE_KEY)
+    location.reload()
+  } else {
+    // 关闭 → 开启:存偏好,动态注入脚本
+    localStorage.setItem(STORAGE_KEY, '1')
+    annotationsEnabled.value = true
+    loadHypothesis()
+  }
+}
+
+onMounted(() => {
+  // 恢复划词标注偏好(若用户之前开启过)
+  if (typeof localStorage !== 'undefined' && localStorage.getItem(STORAGE_KEY) === '1') {
+    annotationsEnabled.value = true
+    loadHypothesis()
+  }
+  load()
+})
 watch(() => route.path, () => nextTick(load))
 watch(isDark, syncTheme)
 </script>
 
 <template>
   <div class="comments">
-    <h2 class="comments__title">{{ giscusLang() === 'en' ? '💬 Comments' : '💬 评论' }}</h2>
+    <h2 class="comments__title">{{ isEn() ? '💬 Comments' : '💬 评论' }}</h2>
+
+    <button
+      class="comments__annotate"
+      :class="{ on: annotationsEnabled }"
+      @click="toggleAnnotations"
+      :title="isEn()
+        ? 'Powered by Hypothesis (hypothes.is). When ON, select text in the article to highlight & comment; a sidebar appears on the right.'
+        : '由 Hypothesis (hypothes.is) 提供。开启后,选中正文文字即可高亮 + 评论;右侧会出现侧边栏。'"
+    >
+      <template v-if="annotationsEnabled">
+        {{ isEn() ? '🖍️ Inline annotations: ON · click to disable' : '🖍️ 划词标注已开启 · 点击关闭' }}
+      </template>
+      <template v-else>
+        {{ isEn() ? '🖍️ Enable inline annotations (Hypothesis)' : '🖍️ 启用划词标注(Hypothesis)' }}
+      </template>
+    </button>
+
     <div ref="container" class="giscus" />
   </div>
 </template>
@@ -75,5 +132,28 @@ watch(isDark, syncTheme)
   font-weight: 600;
   margin-bottom: 16px;
   color: var(--vp-c-text-1);
+}
+.comments__annotate {
+  display: inline-flex;
+  align-items: center;
+  margin-bottom: 18px;
+  padding: 6px 14px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 18px;
+  background: var(--vp-c-bg);
+  color: var(--vp-c-text-2);
+  cursor: pointer;
+  font-size: 13px;
+  line-height: 1.5;
+  transition: 0.18s;
+}
+.comments__annotate:hover {
+  border-color: var(--vp-c-brand-1);
+  color: var(--vp-c-text-1);
+}
+.comments__annotate.on {
+  background: rgba(60, 135, 114, 0.16);
+  color: var(--vp-c-brand-1);
+  border-color: var(--vp-c-brand-1);
 }
 </style>


### PR DESCRIPTION
## 问题

之前 Hypothesis 在 `.vitepress/config.mts` head 里全站默认加载,所有页面右侧都会默认弹出一个 `Annotations / Page Notes` 侧边栏(见截图),挤占阅读空间且大多数访客并不需要。

## 改动

- **`.vitepress/config.mts`**:移除全站 `['script', { src: 'https://hypothes.is/embed.js', async: '' }]`。改为按需注入。
- **`Comments.vue`**:在 h2 标题下、Giscus 容器前加一颗 toggle 按钮。
  - 默认 **OFF**(页面干净,不被侧边栏挤占)
  - 点击启用 → 动态创建 `<script id=hypothesis-embed-script ...>` 注入 head,偏好存 `localStorage.awesome-arch-annotations-enabled` 跨页持久化
  - 再点击关闭 → 清掉偏好 + `location.reload()`,让 Hypothesis 完全离场(SPA 内无法干净卸载,reload 最稳)
  - 中英双语文案 + tooltip 说明用途;`OFF / ON` 两种态视觉区分(灰边 / 品牌绿底)

UX 一句话:**不开能查看,要划词就一键打开**——和你描述的一致。

## 验证

模拟远端构建 `vitepress build` 通过(3.89s,无死链)。

> 注:Comments 组件只在 doc 布局页注入(见 `theme/index.ts` 的 `doc-after` slot),所以首页天然不带这个按钮——首页本来也没有评论区,行为合理。