### PR TITLE
ci: validate VitePress builds on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: Build
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Build (with strict dead-link check)
+        run: pnpm docs:build
+        env:
+          GITHUB_PAGES: 'true'


### PR DESCRIPTION
## What changed

- Added a dedicated pull-request workflow with read-only repository permissions.
- Reused the project's Node 22 and pnpm 10 setup.
- Runs frozen dependency installation and the strict VitePress dead-link build for every PR.
- Leaves GitHub Pages deployment in the existing main-branch workflow.

## Why

The contribution guide says CI checks `pnpm docs:build`, but the existing workflow only runs after changes reach `main`. Build failures and dead links therefore were not caught before merge.

## Impact

Contributors and maintainers get an early build signal on pull requests without granting deployment permissions to forked code.

## Validation

- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- `GITHUB_PAGES=true pnpm docs:build`

