### PR TITLE
fix(site): localize and make interactive widgets accessible

### DIFF
--- a/.vitepress/theme/components/DecisionCard.vue
+++ b/.vitepress/theme/components/DecisionCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { useData } from 'vitepress'
+import { computed, ref } from 'vue'
 
 defineProps<{
   title: string
@@ -11,6 +12,13 @@ defineProps<{
 }>()
 
 const show = ref(false)
+const { lang } = useData()
+
+const isEn = computed(() => lang.value?.startsWith('en'))
+const toggleLabel = computed(() => {
+  if (show.value) return isEn.value ? 'Collapse ▲' : '收起 ▲'
+  return isEn.value ? '👉 What would an architect usually choose? ▼' : '👉 架构师通常怎么选?▼'
+})
 </script>
 
 <template>
@@ -27,8 +35,8 @@ const show = ref(false)
         <div class="dc-d">{{ bDesc }}</div>
       </div>
     </div>
-    <button class="dc-btn" @click="show = !show">
-      {{ show ? '收起 ▲' : '👉 架构师通常怎么选?▼' }}
+    <button type="button" class="dc-btn" :aria-expanded="show" @click="show = !show">
+      {{ toggleLabel }}
     </button>
     <div v-if="show" class="dc-verdict">{{ verdict }}</div>
   </div>

--- a/.vitepress/theme/components/Quiz.vue
+++ b/.vitepress/theme/components/Quiz.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { useData } from 'vitepress'
+import { computed, ref } from 'vue'
 
 const props = defineProps<{
   question: string
@@ -10,6 +11,17 @@ const props = defineProps<{
 
 const picked = ref<number | null>(null)
 const answered = ref(false)
+const { lang } = useData()
+
+const isEn = computed(() => lang.value?.startsWith('en'))
+const answerLabel = computed(() => String.fromCharCode(65 + props.answer))
+const resultText = computed(() => {
+  if (picked.value === props.answer) return isEn.value ? '✅ Correct!' : '✅ 答对了!'
+  return isEn.value
+    ? `❌ Try again — the correct answer is ${answerLabel.value}`
+    : `❌ 再想想——正确答案是 ${answerLabel.value}`
+})
+const resetLabel = computed(() => (isEn.value ? 'Retry this question' : '重做这题'))
 
 function choose(i: number) {
   if (answered.value) return
@@ -23,29 +35,32 @@ function reset() {
 </script>
 
 <template>
-  <div class="quiz">
+  <div class="quiz" role="group" :aria-label="question">
     <div class="quiz-q"><span class="quiz-icon">🤔</span>{{ question }}</div>
     <ul class="quiz-opts">
-      <li
-        v-for="(opt, i) in options"
-        :key="i"
-        :class="[
-          'quiz-opt',
-          answered && i === answer ? 'correct' : '',
-          answered && i === picked && i !== answer ? 'wrong' : '',
-        ]"
-        @click="choose(i)"
-      >
-        <span class="quiz-mark">{{ String.fromCharCode(65 + i) }}</span>
-        <span class="quiz-text">{{ opt }}</span>
-        <span v-if="answered && i === answer" class="quiz-badge ok">✓</span>
-        <span v-else-if="answered && i === picked" class="quiz-badge no">✗</span>
+      <li v-for="(opt, i) in options" :key="i">
+        <button
+          type="button"
+          :class="[
+            'quiz-opt',
+            answered && i === answer ? 'correct' : '',
+            answered && i === picked && i !== answer ? 'wrong' : '',
+          ]"
+          :disabled="answered"
+          :aria-pressed="picked === i"
+          @click="choose(i)"
+        >
+          <span class="quiz-mark">{{ String.fromCharCode(65 + i) }}</span>
+          <span class="quiz-text">{{ opt }}</span>
+          <span v-if="answered && i === answer" class="quiz-badge ok">✓</span>
+          <span v-else-if="answered && i === picked" class="quiz-badge no">✗</span>
+        </button>
       </li>
     </ul>
-    <div v-if="answered" class="quiz-exp">
-      <strong>{{ picked === answer ? '✅ 答对了!' : '❌ 再想想——正确答案是 ' + String.fromCharCode(65 + answer) }}</strong>
+    <div v-if="answered" class="quiz-exp" role="status" aria-live="polite">
+      <strong>{{ resultText }}</strong>
       <p v-if="explanation">{{ explanation }}</p>
-      <button class="quiz-reset" @click="reset">重做这题</button>
+      <button type="button" class="quiz-reset" @click="reset">{{ resetLabel }}</button>
     </div>
   </div>
 </template>
@@ -63,11 +78,14 @@ function reset() {
 .quiz-opts { list-style: none; padding: 0; margin: 0; }
 .quiz-opt {
   display: flex; align-items: center; gap: 10px;
+  width: 100%; text-align: left; font: inherit; color: inherit;
   padding: 10px 14px; margin: 8px 0;
   border: 1px solid var(--vp-c-divider); border-radius: 8px;
-  cursor: pointer; transition: all 0.2s;
+  background: transparent; cursor: pointer; transition: all 0.2s;
 }
-.quiz-opt:hover { border-color: var(--vp-c-brand-1); background: var(--vp-c-brand-soft); }
+.quiz-opt:not(:disabled):hover { border-color: var(--vp-c-brand-1); background: var(--vp-c-brand-soft); }
+.quiz-opt:focus-visible { outline: 2px solid var(--vp-c-brand-1); outline-offset: 2px; }
+.quiz-opt:disabled { cursor: default; opacity: 1; }
 .quiz-opt.correct { border-color: #3c8772; background: rgba(60, 135, 114, 0.14); }
 .quiz-opt.wrong { border-color: #d65c5c; background: rgba(214, 92, 92, 0.12); }
 .quiz-mark {


### PR DESCRIPTION
## What changed

- Localized Quiz feedback, retry text, and DecisionCard controls from the active VitePress locale.
- Replaced click-only Quiz list items with native buttons that support Tab, Enter, and Space.
- Added visible keyboard focus, answer locking, live result announcements, and expanded-state semantics.

## Why

The shared interactive components hard-coded Chinese controls on English pages. Quiz answers were also attached to non-focusable list items, so keyboard users could not complete the interaction.

## Impact

English pages now stay in English, Chinese behavior is preserved, and quizzes are operable with a keyboard and more understandable to assistive technology.

## Validation

- `git diff --check`
- `GITHUB_PAGES=true pnpm docs:build`
- Playwright smoke test on `/en/`: focused an answer and submitted with Enter; English feedback and retry control rendered correctly.
- Playwright smoke test on `/`: Chinese DecisionCard text remained intact and Quiz options rendered as buttons.

