### PR TITLE
fix: correct English tutorial count from 34 to 40

### DIFF
--- a/README_en.md
+++ b/README_en.md
@@ -192,7 +192,7 @@ Each template is an "architecture map". We **deliberately avoid discussing langu
 
 > 👉 **Want to add your own template?** Follow the unified format in [templates/_TEMPLATE.md](templates/_TEMPLATE.md).
 
-> 📝 **Now fully bilingual** — all **34 tutorial chapters, 31 templates, and the first 6 cases** are available in English. Use the language switch (top-right on the site), or browse `en/` in the repo.
+> 📝 **Now fully bilingual** — **34 of 40 tutorial chapters, 31 templates, and the first 6 cases** are available in English. Use the language switch (top-right on the site), or browse `en/` in the repo.
 
 ---
 

--- a/en/index.md
+++ b/en/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: "Awesome Architecture"
   text: "Think like an architect"
-  tagline: "Writing code is disappearing; judgment is what's getting valuable. 34 architecture-thinking chapters + 31 real-system architecture maps + 6 end-to-end cases — architecture only, no syntax."
+  tagline: "Writing code is disappearing; judgment is what's getting valuable. 40 architecture-thinking chapters (34 translated to English) + 31 real-system architecture maps + 6 end-to-end cases — architecture only, no syntax."
   actions:
     - theme: brand
       text: Start the tutorial →
@@ -37,7 +37,7 @@ features:
     details: Each template links to real open-source projects and engineering papers (vLLM, LiteLLM, TigerBeetle, Uber H3, Figma…).
 ---
 
-> ✅ **Fully bilingual.** All 34 tutorial chapters, 31 templates, and the first 6 cases are available in English — use the language switch (top-right) or browse `en/` in the repo. [Contributions welcome](https://github.com/study8677/awesome-architecture).
+> ✅ **Fully bilingual.** 34 of 40 tutorial chapters, all 31 templates, and the first 6 cases are available in English — use the language switch (top-right) or browse `en/` in the repo. [Contributions welcome](https://github.com/study8677/awesome-architecture).
 
 ## 🗺️ Browse all 31 architecture maps
 


### PR DESCRIPTION
## Problem

The English homepage (`en/index.md`) and README (`README_en.md`) claim the project has "34 architecture-thinking chapters." The project actually has **40** tutorial chapters in Chinese (`tutorial/01-` through `tutorial/40-`); only 34 have been translated to English so far. The current wording may misleads English readers into thinking the entire curriculum is 34 chapters, rather than "40 total, 34 translated."

---
英文首页（`en/index.md`）和 README（`README_en.md`）声称项目有"34 章架构思维教程"。实际上项目共有 **40** 章中文教程（`tutorial/01-` 到 `tutorial/40-`），其中只有 34 章已翻译为英文。当前的措辞可能会误导英文读者，让他们以为整个课程体系只有 34 章，而非"共 40 章，已翻译 34 章"。

## Changes

**`en/index.md`** (2 fixes):

- Tagline: `34 architecture-thinking chapters` → `40 architecture-thinking chapters (34 translated to English)`

- Bilingual notice: `All 34 tutorial chapters` → `34 of 40 tutorial chapters, all 31 templates`

**`README_en.md`** (1 fix):

- Line 195: `all **34 tutorial chapters**` → `**34 of 40 tutorial chapters**`

## Verification

- All changes are text-only (no links, no structure, no code modified)
- No new files added, no files deleted
- `pnpm docs:build` dead-link check is not affected (no links changed)
---
- 所有改动仅为文字修正（无链接、无结构、无代码变更）
- 未新增、未删除任何文件
- `pnpm docs:build` 死链检查不受影响（未改动任何链接）