### PR TITLE
docs: fix broken star history charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,11 +252,11 @@ awesome-architecture/
 
 > 如果它帮到了你,点颗 Star 就是对它最好的鼓励。
 
-<a href="https://star-history.com/#study8677/awesome-architecture&Date">
+<a href="https://star-history.dera.page/#study8677/awesome-architecture&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=study8677/awesome-architecture&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=study8677/awesome-architecture&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=study8677/awesome-architecture&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=study8677/awesome-architecture&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=study8677/awesome-architecture&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=study8677/awesome-architecture&type=Date" />
   </picture>
 </a>
 

--- a/README_en.md
+++ b/README_en.md
@@ -254,11 +254,11 @@ Contributions are welcome — new templates, fixes, and especially **English tra
 
 > If this repo helped you, a Star is the best encouragement.
 
-<a href="https://star-history.com/#study8677/awesome-architecture&Date">
+<a href="https://star-history.dera.page/#study8677/awesome-architecture&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=study8677/awesome-architecture&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=study8677/awesome-architecture&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=study8677/awesome-architecture&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=study8677/awesome-architecture&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=study8677/awesome-architecture&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=study8677/awesome-architecture&type=Date" />
   </picture>
 </a>
 


### PR DESCRIPTION
The current star history charts are broken and no longer display repository growth. Update the charts in both README versions so the star history remains available.