### PR TITLE
docs: add yylo to ai agent platform references

### DIFF
--- a/en/templates/ai-agent-platform/README.md
+++ b/en/templates/ai-agent-platform/README.md
@@ -199,6 +199,7 @@ Core entities: `task / session`; `step trace`; `memory`; `tool definitions`; `ch
 - [langgenius/dify](https://github.com/langgenius/dify) — a visual LLM application / Agent workflow platform with built-in tools, RAG, and observability, great for rapid building.
 - [langchain-ai/langgraph](https://github.com/langchain-ai/langgraph) — an orchestration framework that models stateful, long-running Agents as a "graph," supporting durable execution and human-in-the-loop.
 - [langchain-ai/langchain](https://github.com/langchain-ai/langchain) — the most classic LLM application framework, one of the de facto standards for tool calling / memory / chained orchestration.
+- [yylo-dev/yylo](https://github.com/yylo-dev/yylo) — a command-line orchestrator for coding agents: typed tasks, validation, and merge boundaries in a dedicated git worktree, for receipt-backed repository changes.
 
 **📖 Engineering articles:**
 - [Anthropic: Building Effective Agents](https://www.anthropic.com/research/building-effective-agents) — a must-read. It makes the "workflow vs Agent" boundary clear, along with the engineering philosophy of "keep it simple, add complexity only as needed."

--- a/templates/ai-agent-platform/README.md
+++ b/templates/ai-agent-platform/README.md
@@ -194,6 +194,7 @@ Agent 平台 = **给大模型装上「手脚(工具)+ 记忆 + 一个行动循�
 - [langgenius/dify](https://github.com/langgenius/dify) — 可视化的 LLM 应用 / Agent 工作流平台,内置工具、RAG、可观测,适合快速搭建。
 - [langchain-ai/langgraph](https://github.com/langchain-ai/langgraph) — 用「图」建模有状态、长时运行 Agent 的编排框架,支持持久执行与 human-in-the-loop。
 - [langchain-ai/langchain](https://github.com/langchain-ai/langchain) — 最经典的 LLM 应用框架,工具调用 / 记忆 / 链式编排的事实标准之一。
+- [yylo-dev/yylo](https://github.com/yylo-dev/yylo) — 命令行编码 agent 编排器:把类型化任务、验证与合并边界放进专用 git worktree,面向有回执的仓库改动。
 
 **📖 工程文章:**
 - [Anthropic: Building Effective Agents](https://www.anthropic.com/research/building-effective-agents) — 必读。讲清「工作流 vs Agent」的边界,以及「保持简单、按需增复杂度」的工程哲学。


### PR DESCRIPTION
Adds [yylo-dev/yylo](https://github.com/yylo-dev/yylo) to the "Open-source prototypes" list of the **AI Agent / Workflow Platform** template, in both the Chinese and English mirrors — the same reference-row shape as the merged #43 (bifrost → ai-gateway), one row per file.

**What YYLO is** (description taken verbatim from the repo's README, L3/L271): a command-line orchestrator for coding agents — typed tasks, validation, and merge boundaries run in a dedicated git worktree, for receipt-backed repository changes. It sits on the "code-level orchestration framework" end of this template's spectrum (alongside LangGraph), specialized for coding agents rather than visual app building.

**Repo facts:** MIT-licensed, actively maintained (daily pushes), installable via `npm install -g @yylo/cli`, 57★.

**Disclosure:** I'm a contributor to the YYLO project, submitting in the spirit of CONTRIBUTING ("真实开源项目" reference rows). Happy to refile or trim the description if you'd like different framing — or to drop this if you'd rather keep the list to the canonical platforms only.
